### PR TITLE
Update pillow version in requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,8 @@ mock==2.0.0
 num2words==0.5.6
 ofxparse==0.16
 passlib==1.6.5
-Pillow==4.0.0
+Pillow==4.0.0 ;  python_version < '3.7'
+Pillow==5.2.0 ;  python_version >= '3.7'
 psutil==4.3.1; sys_platform != 'win32'
 psycopg2==2.7.3.1; sys_platform != 'win32'
 pydot==1.2.3


### PR DESCRIPTION
python 3.7 will not support pillow 4.0. 
Update code for pillow version installation depends on python version.

Description of the issue/feature this PR addresses:
When I install odoo 12 on mac with requirement.txt and I got an error on pillow library. 

Current behavior before PR:
if python >= 3.7 installed on the computer, odoo requirement installation will be failed by pillow version.

Desired behavior after PR is merged:
requirement will install correct version of pillow library depends on python version.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
